### PR TITLE
Expanded navbar item to accept classes

### DIFF
--- a/components/navbar.pug
+++ b/components/navbar.pug
@@ -17,16 +17,18 @@ mixin navbar(name, id, style, href)
 			ul.nav.navbar-nav
 				block
 
-mixin nav_item(href, active)
+mixin nav_item(href, style, active)
+	- var ddstyle = style || ''
+	- if(!!active && ddstyle.indexOf("active") == -1) ddstyle += (ddstyle.length == 0 ? "active" : " active")
 
-	if(active)
-		li(class="active"): a( href=href ): block
-	else
-		li: a( href=href ): block
+	li(class=ddstyle): a( href=href ): block
 
-mixin nav_item_dropdown(href, active)
-	- var ddclass = active ? ["dropdown", "active"] : "dropdown"
-	li(class=ddclass)
+mixin nav_item_dropdown(href, style, active)
+	- var ddstyle = style || ''
+	- if(ddstyle.indexOf("dropdown") == -1) ddstyle = (ddstyle.length == 0 ? "dropdown" : "dropdown " + ddstyle)
+	- if(!!active && ddstyle.indexOf("active") == -1) ddstyle += " active"
+
+	li(class=ddstyle)
 		a.dropdown-toggle( href=href, data-toggle="dropdown", role="button", aria-expanded="false" )= attributes.label
 			span.caret
 		ul.dropdown-menu( role="menu" )

--- a/test/fixtures/navbars/nav-item-dropdown.pug
+++ b/test/fixtures/navbars/nav-item-dropdown.pug
@@ -1,2 +1,2 @@
 include ../../../components/navbar.pug
-+nav_item_dropdown(href, active)
++nav_item_dropdown(href, style, active)

--- a/test/fixtures/navbars/navbar-item.pug
+++ b/test/fixtures/navbars/navbar-item.pug
@@ -1,2 +1,2 @@
 include ../../../components/navbar.pug
-+nav_item(href, active) Test
++nav_item(href, style, active) Test

--- a/test/navbars.js
+++ b/test/navbars.js
@@ -41,13 +41,39 @@ describe("Navbars", function () {
         var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "navbar-item.pug"));
         assert.equal('<li><a href="href">Test</a></li>', fn(locals));
     });
+    it('should generate a navbar item', function () {
+        var locals = {
+            href: 'href',
+            style: 'style'
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "navbar-item.pug"));
+        assert.equal('<li class="style"><a href="href">Test</a></li>', fn(locals));
+    });
     it('should generate an active navbar item', function () {
         var locals = {
             href: 'href',
+            style: 'style',
             active: true
         };
         var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "navbar-item.pug"));
-        assert.equal('<li class="active"><a href="href">Test</a></li>', fn(locals));
+        assert.equal('<li class="style active"><a href="href">Test</a></li>', fn(locals));
+    });
+    it('should generate an active navbar item', function () {
+        var locals = {
+            href: 'href',
+            style: 'style active',
+            active: true
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "navbar-item.pug"));
+        assert.equal('<li class="style active"><a href="href">Test</a></li>', fn(locals));
+    });
+    it('should generate an active navbar item', function () {
+        var locals = {
+            href: 'href',
+            style: 'style active'
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "navbar-item.pug"));
+        assert.equal('<li class="style active"><a href="href">Test</a></li>', fn(locals));
     });
     it('should generate a navbar divider', function () {
         var locals = {};
@@ -61,13 +87,56 @@ describe("Navbars", function () {
         var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
         assert.equal('<li class="dropdown"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
     });
+    it('should generate a navbar dropdown', function () {
+        var locals = {
+            href: 'href',
+            style: 'style'
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
+        assert.equal('<li class="dropdown style"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+    });
     it('should generate an active navbar dropdown', function () {
         var locals = {
             href: 'href',
+            style: 'style',
             active: true
         };
         var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
-        assert.equal('<li class="dropdown active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+        assert.equal('<li class="dropdown style active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+    });
+    it('should generate an active navbar dropdown', function () {
+        var locals = {
+            href: 'href',
+            style: 'style active',
+            active: true
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
+        assert.equal('<li class="dropdown style active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+    });
+    it('should generate an active navbar dropdown', function () {
+        var locals = {
+            href: 'href',
+            style: 'style active'
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
+        assert.equal('<li class="dropdown style active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+    });
+    it('should generate an active navbar dropdown', function () {
+        var locals = {
+            href: 'href',
+            style: 'dropdown style active',
+            active: true
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
+        assert.equal('<li class="dropdown style active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
+    });
+    it('should generate an active navbar dropdown', function () {
+        var locals = {
+            href: 'href',
+            style: 'dropdown style active'
+        };
+        var fn = jade.compileFile(path.join(__dirname, "fixtures/navbars", "nav-item-dropdown.pug"));
+        assert.equal('<li class="dropdown style active"><a class="dropdown-toggle" href="href" data-toggle="dropdown" role="button" aria-expanded="false"><span class="caret"></span></a><ul class="dropdown-menu" role="menu"></ul></li>', fn(locals));
     });
     it('should generate a navbar header', function () {
         var locals = {};


### PR DESCRIPTION
I needed this to add classes to the items in order to easily control visibility according to user permissions.

As there is a new optional parameter, it breaks interface of the mixin.