### PR TITLE
Corrected input-simple and textarea-simple to include name attribute

### DIFF
--- a/components/forms.pug
+++ b/components/forms.pug
@@ -7,7 +7,7 @@ mixin input(type,id,placeholder,label,name)
 
 //- Simple form input control without a form-group
 mixin input-simple(type,id,placeholder)
-    input.form-control(type=type,id=id,placeholder=placeholder)
+    input.form-control(type=type,id=id,placeholder=placeholder,name=id)
 
 //- Input control with form-group wrapper
 mixin textarea(id,placeholder,label,name,rows)

--- a/components/forms.pug
+++ b/components/forms.pug
@@ -19,7 +19,7 @@ mixin textarea(id,placeholder,label,name,rows)
 //- Simple form input control without a form-group
 mixin textarea-simple(id,placeholder,rows)
     - rows = rows || 3 //- Default of 3 rows
-    textarea.form-control(id=id,placeholder=placeholder,rows=rows)
+    textarea.form-control(id=id,placeholder=placeholder,name=id,rows=rows)
 
 //- Checkbox - Block style
 mixin checkbox(text,name,id)

--- a/test/forms.js
+++ b/test/forms.js
@@ -20,7 +20,7 @@ describe("Forms", function() {
 
     it("should generate simple text area control", function() {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/forms","textarea-simple.pug"));
-        assert.equal('<textarea class="form-control" id="txtInput" placeholder="Placeholder" rows="3"></textarea>',fn({id: "txtInput",placeholder:"Placeholder"}));
+        assert.equal('<textarea class="form-control" id="txtInput" placeholder="Placeholder" name="txtInput" rows="3"></textarea>',fn({id: "txtInput",placeholder:"Placeholder"}));
     });
 
     it("should generate a checkbox",function() {

--- a/test/forms.js
+++ b/test/forms.js
@@ -10,7 +10,7 @@ describe("Forms", function() {
 
     it("should generate simple input control", function() {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/forms","input-simple.pug"));
-        assert.equal('<input class="form-control" type="text" id="txtInput" placeholder="Placeholder"/>',fn({type: "text", id: "txtInput",placeholder:"Placeholder"}));
+        assert.equal('<input class="form-control" type="text" id="txtInput" placeholder="Placeholder" name="txtInput"/>',fn({type: "text", id: "txtInput",placeholder:"Placeholder"}));
     });
 
     it("should generate text area control", function() {

--- a/test/progress-bar.js
+++ b/test/progress-bar.js
@@ -5,27 +5,27 @@ var path = require("path");
 describe("Progress bars", function() {
     it("should generate a generic progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60,type: "primary" }));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60,type: "primary" }));
     });
     it("should generate a primary progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar-primary.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-primary" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
     });
     it("should generate a info progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar-info.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
     });
     it("should generate a warning progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar-warning.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
     });
     it("should generate a danger progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar-danger.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-danger" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60 }));
     });
     it("should generate a success progress bar",function() {
         var fn = pug.compileFile(path.join(__dirname,"fixtures/progress-bar","progress-bar-success.pug"));
-        assert.equal('<div class="progress"><div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60}));
+        assert.equal('<div class="progress"><div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" style="width: 60%;"><span class="sr-only">60% Complete</span></div></div>',fn({value: 60}));
     });
 });
 


### PR DESCRIPTION
Without the name attribute the backend won't receive these element data.