### PR TITLE
A little bug in tabs.pug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 # pug-bootstrap
 
 A port of [JADE-Bootstrap](http://rajasegar.github.io/JADE-Bootstrap/) from jade to pug.
+
+This repo is for modifing several bugs found in the original repo [pug-bootstrap](https://github.com/mike-goodwin/pug-bootstrap)

--- a/components/tabs.pug
+++ b/components/tabs.pug
@@ -36,7 +36,7 @@ mixin tab-pills-list(tabs,active,options)
 mixin tab(id,active,options)
 	- options = options || {};
 	- var style = options.style || '';
-	- style = style.replace(/\bnav-pane\b/, '')
+	- style = style.replace(/\btab-pane\b/, '')
 	- if(active && style.indexOf("active") == -1) style += (style.length == 0 ? "active" : " active")
-	.nav-pane(id=`tab${id}`, class=style)
+	.tab-pane(id=`tab${id}`, class=style)
 		block

--- a/test/tabs.js
+++ b/test/tabs.js
@@ -29,7 +29,7 @@ describe('Tabs', function () {
 
     it('should render nav tabs with content', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab-list.pug'));
-        var expected = '<ul class="nav nav-tabs" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content"><div class="nav-pane active" id="tabitem1"></div><div class="nav-pane" id="tabitem2"></div><div class="nav-pane test" id="tabitem3"></div></div>';
+        var expected = '<ul class="nav nav-tabs" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content"><div class="tab-pane active" id="tabitem1"></div><div class="tab-pane" id="tabitem2"></div><div class="tab-pane test" id="tabitem3"></div></div>';
         var locals = {
             tabs: items,
             active: 1
@@ -39,7 +39,7 @@ describe('Tabs', function () {
 
     it('should render nav tabs headers with custom styles and content', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab-list.pug'));
-        var expected = '<ul class="nav nav-tabs test" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content"><div class="nav-pane active" id="tabitem1"></div><div class="nav-pane" id="tabitem2"></div><div class="nav-pane test" id="tabitem3"></div></div>';
+        var expected = '<ul class="nav nav-tabs test" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content"><div class="tab-pane active" id="tabitem1"></div><div class="tab-pane" id="tabitem2"></div><div class="tab-pane test" id="tabitem3"></div></div>';
         var locals = {
             tabs: items,
             active: 1,
@@ -71,7 +71,7 @@ describe('Tabs', function () {
 
     it('should render nav pills with content', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab-pills.pug'));
-        var expected = '<ul class="nav nav-pills" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content clearfix"><div class="nav-pane active" id="tabitem1"></div><div class="nav-pane" id="tabitem2"></div><div class="nav-pane test" id="tabitem3"></div></div>';
+        var expected = '<ul class="nav nav-pills" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content clearfix"><div class="tab-pane active" id="tabitem1"></div><div class="tab-pane" id="tabitem2"></div><div class="tab-pane test" id="tabitem3"></div></div>';
         var locals = {
             tabs: items,
             active: 1
@@ -81,7 +81,7 @@ describe('Tabs', function () {
 
     it('should render nav pills headers with custom styles and content', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab-pills.pug'));
-        var expected = '<ul class="nav nav-pills test" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content clearfix"><div class="nav-pane active" id="tabitem1"></div><div class="nav-pane" id="tabitem2"></div><div class="nav-pane test" id="tabitem3"></div></div>';
+        var expected = '<ul class="nav nav-pills test" role="tablist"><li><a href="#tabitem1" role="tab" data-toggle="tab">item1</a></li><li class="active"><a href="#tabitem2" role="tab" data-toggle="tab">item2</a></li><li><a href="#tabitem3" role="tab" data-toggle="tab">item3</a></li></ul><div class="tab-content clearfix"><div class="tab-pane active" id="tabitem1"></div><div class="tab-pane" id="tabitem2"></div><div class="tab-pane test" id="tabitem3"></div></div>';
         var locals = {
             tabs: items,
             active: 1,
@@ -92,7 +92,7 @@ describe('Tabs', function () {
 
     it('should render active tab', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab.pug'));
-        var expected = '<div class="nav-pane active" id="tabtest"></div>';
+        var expected = '<div class="tab-pane active" id="tabtest"></div>';
         var locals = {
             id: 'test',
             active: true
@@ -102,7 +102,7 @@ describe('Tabs', function () {
 
     it('should render tab with custom styles', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab.pug'));
-        var expected = '<div class="nav-pane test" id="tabtest"></div>';
+        var expected = '<div class="tab-pane test" id="tabtest"></div>';
         var locals = {
             id: 'test',
             active: false,
@@ -113,7 +113,7 @@ describe('Tabs', function () {
 
     it('should render active tab with custom styles', function () {
         var fn = pug.compileFile(path.join(__dirname, "fixtures/tabs", 'tab.pug'));
-        var expected = '<div class="nav-pane test active" id="tabtest"></div>';
+        var expected = '<div class="tab-pane test active" id="tabtest"></div>';
         var locals = {
             id: 'test',
             active: true,


### PR DESCRIPTION
Thank you for your great job on porting Jade-bootstrap to pug.

There is a little bug in tabs.pug around line 39 and 41.

the replace() function was taking a attribute named "nav-pane". But the correct name is "tab-pane".
The attribute "nav-pane" can not be "active" and "inactive", then all of items will be printed at one time (in other words, it can not be changed with clicking on the tab item).

So I referred the HTML code in the homepage of JADE-Bootstrap, turns out the correct attribute name is "tab-pane". So I modified it in my forked repo, it seems like working well.

So I just let you know about it, if you want to solve this bug, please merge this pull request.